### PR TITLE
Heat-Cool Support

### DIFF
--- a/Tech.Aerove.StreamDeck.NestControl/Actions/SetMode.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Actions/SetMode.cs
@@ -82,12 +82,12 @@ namespace Tech.Aerove.StreamDeck.NestControl.Actions
             if (Thermostat.Mode == ThermostatMode.COOL)
             {
                 await Dispatcher.SetImageAsync(ImageColors.Blue.DataUri);
-                await Dispatcher.SetTitleAsync($"{Thermostat.Mode}\n{Thermostat.SetPoint}");
+                await Dispatcher.SetTitleAsync($"{Thermostat.Mode}\n{Thermostat.SetPointRender}");
             }
             else if (Thermostat.Mode == ThermostatMode.HEAT)
             {
                 await Dispatcher.SetImageAsync(ImageColors.Red.DataUri);
-                await Dispatcher.SetTitleAsync($"{Thermostat.Mode}\n{Thermostat.SetPoint}");
+                await Dispatcher.SetTitleAsync($"{Thermostat.Mode}\n{Thermostat.SetPointRender}");
             }
             else if (Thermostat.Mode == ThermostatMode.HEATCOOL)
             {

--- a/Tech.Aerove.StreamDeck.NestControl/Actions/TemperatureDown.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Actions/TemperatureDown.cs
@@ -32,7 +32,6 @@ namespace Tech.Aerove.StreamDeck.NestControl.Actions
         }
         public override async Task KeyDownAsync(int userDesiredState)
         {
-            if (Thermostat.Mode == ThermostatMode.HEATCOOL) { await Dispatcher.ShowAlertAsync(); return; }
             if (Thermostat.Mode == ThermostatMode.OFF)
             {
                 Thermostat.SetMode(ThermostatMode.COOL);

--- a/Tech.Aerove.StreamDeck.NestControl/Actions/TemperatureUp.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Actions/TemperatureUp.cs
@@ -36,7 +36,6 @@ namespace Tech.Aerove.StreamDeck.NestControl.Actions
         }
         public override async Task KeyDownAsync(int userDesiredState)
         {
-            if (Thermostat.Mode == ThermostatMode.HEATCOOL) { await Dispatcher.ShowAlertAsync(); return; }
             if (Thermostat.Mode == ThermostatMode.OFF)
             {
                 Thermostat.SetMode(ThermostatMode.HEAT);

--- a/Tech.Aerove.StreamDeck.NestControl/Actions/ThermostatInfo.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Actions/ThermostatInfo.cs
@@ -80,19 +80,19 @@ namespace Tech.Aerove.StreamDeck.NestControl.Actions
                     {
                         await Dispatcher.SetStateAsync(1);
                         await Dispatcher.SetImageAsync(ImageColors.Blue.DataUri);
-                        modeText = $"{mode}\n{Thermostat.SetPoint}";
+                        modeText = $"{mode}\n{Thermostat.SetPointRender}";
                     }
                     if (Thermostat.Mode == ThermostatMode.HEAT)
                     {
                         await Dispatcher.SetStateAsync(1);
                         await Dispatcher.SetImageAsync(ImageColors.Red.DataUri);
-                        modeText = $"{mode}\n{Thermostat.SetPoint}";
+                        modeText = $"{mode}\n{Thermostat.SetPointRender}";
                     }
                     if (Thermostat.Mode == ThermostatMode.HEATCOOL)
                     {
                         await Dispatcher.SetStateAsync(1);
                         await Dispatcher.SetImageAsync(ImageColors.RedBlue.DataUri);
-                        modeText = "H&C\n";
+                        modeText = $"H&C\n{Thermostat.SetPointRender}";
                     }
                     if (Thermostat.Mode == ThermostatMode.OFF)
                     {

--- a/Tech.Aerove.StreamDeck.NestControl/Tech.Aerove.Tools/Nest/Models/DevicesResponseExtensions.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Tech.Aerove.Tools/Nest/Models/DevicesResponseExtensions.cs
@@ -29,40 +29,26 @@ namespace Tech.Aerove.Tools.Nest.Models
             return (TemperatureScale)Enum.Parse(typeof(TemperatureScale), device.Traits.SdmDevicesTraitsSettings.TemperatureScale);
         }
 
-        public static decimal GetTemperatureSetPoint(this Device device, bool convertScale = false)
+        public static SdmDevicesTraitsThermostatTemperatureSetpoint GetTemperatureSetPoint(this Device device, bool convertScale = false)
         {
-            var mode = device.GetMode();
-            if (mode != ThermostatMode.COOL && mode != ThermostatMode.HEAT) { return 0; }
-            decimal setPoint = 0;
-            if (mode == ThermostatMode.COOL)
-            {
-                setPoint = device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.CoolCelsius;
-            }
-            else
-            {
-                setPoint = device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.HeatCelsius;
-            }
+            var setPoint = device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.Clone();
             if (convertScale && device.GetTemperatureScale() == TemperatureScale.FAHRENHEIT)
             {
-                setPoint = setPoint.ToFahrenheit();
+                setPoint.CoolCelsius = setPoint.CoolCelsius.ToFahrenheit();
+                setPoint.HeatCelsius = setPoint.HeatCelsius.ToFahrenheit();
             }
             return setPoint;
         }
-        public static int GetTemperatureSetPointAsInt(this Device device, bool convertScale = false)
-        {
-            var setPoint = device.GetTemperatureSetPoint(convertScale);
-            return Convert.ToInt32(Math.Round(setPoint));
-        }
 
-        public static void SetTemperatureSetPoint(this Device device, ThermostatMode mode, decimal value)
+        public static void SetTemperatureSetPoint(this Device device, ThermostatMode mode, SdmDevicesTraitsThermostatTemperatureSetpoint value)
         {
-            if (mode == ThermostatMode.COOL)
+            if (mode == ThermostatMode.COOL || mode == ThermostatMode.HEATCOOL)
             {
-                device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.CoolCelsius = value;
+                device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.CoolCelsius = value.CoolCelsius;
             }
-            else
+            if(mode == ThermostatMode.HEAT || mode == ThermostatMode.HEATCOOL)
             {
-                device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.HeatCelsius = value;
+                device.Traits.SdmDevicesTraitsThermostatTemperatureSetpoint.HeatCelsius = value.HeatCelsius;
             }
         }
 

--- a/Tech.Aerove.StreamDeck.NestControl/Tech.Aerove.Tools/Nest/Models/ThermostatDevice.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Tech.Aerove.Tools/Nest/Models/ThermostatDevice.cs
@@ -16,8 +16,28 @@ namespace Tech.Aerove.Tools.Nest.Models
         public ThermostatMode Mode => Device.GetMode();
         public ThermostatStatus Status => Device.GetStatus();
         public TemperatureScale Scale => Device.GetTemperatureScale();
-        public int SetPoint => Device.GetTemperatureSetPointAsInt(true);
-        public decimal SetPointExact => Device.GetTemperatureSetPoint(true);
+        public string SetPointRender
+        {
+            get
+            {
+                var mode = Device.GetMode();
+                var setPoint = Device.GetTemperatureSetPoint(true);
+                if (mode == ThermostatMode.COOL)
+                {
+                    return setPoint.CoolCelsius.ToString("F0");
+                }
+                else if (mode == ThermostatMode.HEAT)
+                {
+                    return setPoint.HeatCelsius.ToString("F0");
+                }
+                else if (mode == ThermostatMode.HEATCOOL)
+                {
+                    return $"{setPoint.CoolCelsius.ToString("F0")}-{setPoint.HeatCelsius.ToString("F0")}";
+                }
+                return "Err";
+            }
+        }
+        public SdmDevicesTraitsThermostatTemperatureSetpoint SetPointsExact => Device.GetTemperatureSetPoint(true);
         public int CurrentTemperature => Device.GetCurrentTemperatureAsInt(true);
         public decimal CurrentTemperatureExact => Device.GetCurrentTemperature(true);
         public string Name => Device.GetName();
@@ -27,11 +47,6 @@ namespace Tech.Aerove.Tools.Nest.Models
         public bool SetMode(ThermostatMode mode)
         {
             return NestClient.SetMode(this, mode);
-        }
-
-        public bool SetTemp(decimal value)
-        {
-            return NestClient.SetTemp(this, value);
         }
 
         public bool SetTempUp(int value)

--- a/Tech.Aerove.StreamDeck.NestControl/Tech.Aerove.Tools/Nest/Models/WebCalls/DevicesResponse.cs
+++ b/Tech.Aerove.StreamDeck.NestControl/Tech.Aerove.Tools/Nest/Models/WebCalls/DevicesResponse.cs
@@ -133,11 +133,18 @@ namespace Tech.Aerove.Tools.Nest.Models.WebCalls
         public List<string> AvailableModes { get; set; }
     }
 
-    internal partial class SdmDevicesTraitsThermostatTemperatureSetpoint
+    public partial class SdmDevicesTraitsThermostatTemperatureSetpoint
     {
         [JsonProperty("coolCelsius")]
         public decimal CoolCelsius { get; set; }
         [JsonProperty("heatCelsius")]
         public decimal HeatCelsius { get; set; }
+
+        public SdmDevicesTraitsThermostatTemperatureSetpoint Clone() => 
+            new SdmDevicesTraitsThermostatTemperatureSetpoint
+                {
+                    CoolCelsius = CoolCelsius,
+                    HeatCelsius = HeatCelsius
+                };
     }
 }


### PR DESCRIPTION
Switched temperature passing to use the (heat, cool) pair defined in SdmDevicesTraitsThermostatTemperatureSetpoint. Enabled heat-cool support by moving both values together.